### PR TITLE
Fix search to find "whole" words at end of line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3783,7 +3783,7 @@ int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_searc
 
 				if (col > 0 && _is_text_char(p_search[col-1])) {
 					col = -1;
-				} else if (_is_text_char(p_search[col+p_key.length()])) {
+				} else if ((col + p_key.length()) < p_search.length() && _is_text_char(p_search[col+p_key.length()])) {
 					col = -1;
 				}
 			}


### PR DESCRIPTION
Fix `_get_column_pos_of_word` so that the `SEARCH_WHOLE_WORDS` flag will properly find words that are at the end of a line.

Fixes #7326 .